### PR TITLE
Rename geth to gwhale in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM alpine:3.5
 ADD . /go-ethereum
 RUN \
   apk add --update git go make gcc musl-dev linux-headers && \
-  (cd go-ethereum && make geth)                           && \
-  cp go-ethereum/build/bin/geth /usr/local/bin/           && \
+  (cd go-ethereum && make gwhale)                         && \
+  cp go-ethereum/build/bin/gwhale /usr/local/bin/         && \
   apk del git go make gcc musl-dev linux-headers          && \
   rm -rf /go-ethereum && rm -rf /var/cache/apk/*
 
@@ -12,4 +12,4 @@ EXPOSE 8545
 EXPOSE 30373
 EXPOSE 30373/udp
 
-ENTRYPOINT ["geth"]
+ENTRYPOINT ["gwhale"]


### PR DESCRIPTION
Docker fails to build an image because the geth target doesn't exist in Makefile anymore, neither does geth executable. This pull request fixes the issue by renaming both of them to gwhale.